### PR TITLE
Feature criteria match

### DIFF
--- a/lib/Simples/Request/Search/Criteria.php
+++ b/lib/Simples/Request/Search/Criteria.php
@@ -183,7 +183,36 @@ abstract class Simples_Request_Search_Criteria extends Simples_Base {
 	 * @return array
 	 */
 	protected function _prepare_match() {
-		return $this->get();
+		$data = $this->get();
+
+		if (!isset($data['in']) || !isset($data['value'])) {
+			throw new Simples_Request_Exception('Key "in" or "value" empty', $data) ;
+		}
+
+		if(is_array($data['in'])) {
+			$return = array(
+				'bool' => array(
+					'should' => array(),
+				),
+			);
+
+			foreach($data['in'] as $in) {
+				$return['bool']['should'][] = array(
+					'match' => array(
+						$in => $data['value'],
+					),
+				);
+			}
+		}
+		else {
+			$return = array(
+				'match' => array(
+					$data['in'] => $data['value'],
+				),
+			);
+		}
+
+		return $return;
 	}
 
 	/**

--- a/tests/lib/Simples/Request/Search/CriteriaTest.php
+++ b/tests/lib/Simples/Request/Search/CriteriaTest.php
@@ -99,13 +99,39 @@ class Simples_Request_Search_CriteriaTest extends PHPUnit_Framework_TestCase {
 
 		// Match
 		$criteria = new TestCriteria(array(
-			'values' => array('value1','value2')
+			'in' => 'field1',
+			'value' => 'value1'
 		), array('type' => 'match')) ;
 		$res = $criteria->to('array') ;
 		$expected = array(
-			'value' => array('value1','value2')
+			'match' => array(
+				'field1' => 'value1'
+			),
 		);
 		$this->assertEquals($expected, $res) ;
+
+		$criteria = new TestCriteria(array(
+			'in' => array('field1', 'field2'),
+			'value' => 'value1'
+		), array('type' => 'match'));
+		$res = $criteria->to('array');
+		$expected = array(
+			'bool' => array(
+				'should' => array(
+					array(
+						'match' => array(
+							'field1' => 'value1',
+						)
+					),
+					array(
+						'match' => array(
+							'field2' => 'value1',
+						),
+					)
+				),
+			),
+		);
+		$this->assertEquals($expected, $res);
 
 		// Missing
 		$criteria = new TestCriteria(array(

--- a/tests/lib/Simples/Request/SearchTest.php
+++ b/tests/lib/Simples/Request/SearchTest.php
@@ -369,4 +369,38 @@ class Simples_Request_SearchTest extends PHPUnit_Framework_TestCase {
 		$res = $request->to('array') ;
 		$this->assertTrue(isset($res['query']['geo_distance'])) ;
 	}
+
+	public function testCriteriaMatch() {
+		$request = $this->client->search();
+		$request->query()->options(array('type' => 'match'))->in('field')->match('toto');
+		$this->assertEquals(array(
+			'query' => array(
+				'match' => array(
+					'field' => 'toto',
+				),
+			),
+		), $request->to('array'));
+
+		$request = $this->client->search();
+
+		$request->query()->options(array('type' => 'match'))->in(array('field1', 'field2'))->match('toto');
+		$this->assertEquals(array(
+			'query' => array(
+				'bool' => array(
+					'should' => array(
+						array(
+							'match' => array(
+								'field1' => 'toto',
+							),
+						),
+						array(
+							'match' => array(
+								'field2' => 'toto',
+							),
+						),
+					),
+				),
+			),
+		), $request->to('array'));
+	}
 }


### PR DESCRIPTION
This allows the usage of match queries in single or multiple fields.

The following query on multiple fields...

``` php
$request->query()->options(array('type' => 'match'))->in(array('field1', 'field2'))->match('toto');
```

...will produce this request :

``` json
{
    "query": {
        "bool": {
            "should": [
                {
                    "match": {
                        "field1": "toto"
                    }
                },
                {
                    "match": {
                        "field2": "toto"
                    }
                }
            ]
        }
    }
}
```

And this one with a single field...

``` php
$request->query()->options(array('type' => 'match'))->in('field1')->match('toto');
```

...will produce this request :

``` json
{
    "query": {
        "match": {
            "field1": "jim"
        }
    }
}
```
