### PR TITLE
Implemetation of not terms criteria

### DIFF
--- a/lib/Simples/Request/Search/Criteria.php
+++ b/lib/Simples/Request/Search/Criteria.php
@@ -216,6 +216,35 @@ abstract class Simples_Request_Search_Criteria extends Simples_Base {
 	}
 
 	/**
+	 * Prepare for a "not_terms" clause
+	 *
+	 * @return array
+	 */
+	protected function _prepare_not_terms() {
+		$data = $this->get();
+
+		if (!isset($data['in']) || !isset($data['value'])) {
+			throw new Simples_Request_Exception('Key "in" or "value" empty', $data) ;
+		}
+
+		$return = array(
+			'bool' => array(
+				'must_not' => array(),
+			),
+		);
+
+		foreach((array)$data['in'] as $in) {
+			$return['bool']['must_not'][] = array(
+				'terms' => array(
+					$in => $data['value'],
+				),
+			);
+		}
+
+		return $return;
+	}
+
+	/**
 	 * Prepare for a "term" clause.
 	 *
 	 * @return array

--- a/tests/lib/Simples/Request/Search/CriteriaTest.php
+++ b/tests/lib/Simples/Request/Search/CriteriaTest.php
@@ -267,6 +267,26 @@ class Simples_Request_Search_CriteriaTest extends PHPUnit_Framework_TestCase {
 		), $criteria->to('array'));
 	}
 
+	public function testNotTerms() {
+		$criteria = new TestCriteria(array(
+			'in' => 'ids',
+			'values' => array('1', '2', '3')
+		), array('type' => 'not_terms'));
+		$res = $criteria->to('array') ;
+		$expected = array(
+			'bool' => array(
+				'must_not' => array(
+					array(
+						'terms' => array(
+							'ids' => array('1', '2', '3')
+						)
+					)
+				),
+			),
+		);
+		$this->assertEquals($expected, $res) ;
+	}
+
 	/**
 	 * @dataProvider providerNestedException
 	 * @expectedException Simples_Request_Exception


### PR DESCRIPTION
This allows the use of applications that must not appear in the matching documents

The following query ...
```php
$request->query()->options(array('type' => 'not_terms'))->in('ids')->values(array('1' ,'2', '3'));
```
...will produce this request :

```json
{
    "query": {
        "bool": {
            "must_not": [
                {
                    "terms": {
                        "ids": ["1", "2", "3"]
                    }
                }
            ]
        }
    }
}
```