### PR TITLE
Fix transport exception on invalid return code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = ln
+charset = utf-8
+insert_final_newline = true
+
+[*.php]
+indent_style = tab
+indent_size = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: php
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7
+
+matrix:
+  allow_failures:
+    - php: 7
 
 before_script:
   - ./tests/bin/elasticsearch.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
 
 matrix:
   allow_failures:
+    - php: 5.2
     - php: 7
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ matrix:
 before_script:
   - ./tests/bin/elasticsearch.sh
 
-script: phpunit tests/
+script: phpunit --bootstrap tests/lib/bootstrap.php tests/

--- a/lib/Simples/Transport/Http.php
+++ b/lib/Simples/Transport/Http.php
@@ -32,6 +32,14 @@ class Simples_Transport_Http extends Simples_Transport {
 	 * @var Simples_Transport
 	 */
 	protected $_connection ;
+
+	/**
+	 * Bad HTTP code on curl call
+	 */
+	private static $badHttCode = array(
+		400,
+		500
+	);
 	
 	/**
 	 * Constructor.
@@ -142,16 +150,21 @@ class Simples_Transport_Http extends Simples_Transport {
 				curl_error($this->_connection)
 			);
 		}
+
 		if (!strlen($response)) {
 			throw new Simples_Transport_Exception('The ES server returned an empty response.') ;
 		}
 		
 		$return = json_decode($response, true) ;
-		
 		if ($return === null) {
 			throw new Simples_Transport_Exception('Cannot JSON decode the response : ' . $response) ;
 		}
 		
+		$httpCode = curl_getinfo($this->_connection, CURLINFO_HTTP_CODE);
+		if (in_array($httpCode, self::$badHttCode)) {
+			throw new Simples_Transport_Exception('Error during the request (HTTP CODE: ' . $httpCode . ')');
+		}
+
 		return $return ;
 	}
 }

--- a/tests/lib/Simples/Request/IndexTest.php
+++ b/tests/lib/Simples/Request/IndexTest.php
@@ -14,12 +14,7 @@ class Simples_Request_IndexTest extends PHPUnit_Framework_TestCase {
 	}
 	
 	public function testIndex() {
-		try {
-			$request = new Simples_Request_Index(new Simples_Transport_Http());
-			$this->fail();
-		} catch (Exception $e) {
-			
-		}
+		$request = new Simples_Request_Index(null, null, new Simples_Transport_Http());
 
 		$request = $this->client->index(array(
 				'user' => 'scharrier',

--- a/tests/lib/Simples/Transport/HttpTest.php
+++ b/tests/lib/Simples/Transport/HttpTest.php
@@ -89,8 +89,13 @@ class Simples_Transport_HttpTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testCallCurlHttpCode() {
 		$transport = new Simples_Transport_Http();
-		$transport->call('/test', 'PUT');
-		$res = $transport->call('/test', 'PATCH');
+
+		try {
+			$transport->call('/test', 'DELETE');
+			$transport->call('/test', 'PUT');
+		} catch(Exception $e) {}
+
+		$transport->call('/test', 'POST');
 	}
 
 	public function testMagicCall() {

--- a/tests/lib/Simples/Transport/HttpTest.php
+++ b/tests/lib/Simples/Transport/HttpTest.php
@@ -55,7 +55,34 @@ class Simples_Transport_HttpTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($res['ok']);
 		$this->assertTrue(isset($res['version']['number'])) ;
 	}
-	
+
+	/**
+	 * @expectedException Exception
+	 * @expectedExceptionMessage Cannot JSON decode the response : No handler found for uri [/test] and method [GET]
+	 */
+	public function testCallCannotJsonDecodeException() {
+		$transport = new Simples_Transport_Http();
+		$res = $transport->call('/test');
+	}
+
+	/**
+	 * @expectedException Exception
+	 * @expectedExceptionMessage Error during the request (6)
+	 */
+	public function testCallCurlReturnFalse() {
+		$transport = new Simples_Transport_Http(array( 'host' => 'nowhere' ));
+		$res = $transport->call('/test');
+	}
+
+	/**
+	 * @expectedException Exception
+	 * @expectedExceptionMessage The ES server returned an empty response.
+	 */
+	public function testCallEmptyResponse() {
+		$transport = new Simples_Transport_Http();
+		$res = $transport->call('/test', 'HEAD');
+	}
+
 	public function testMagicCall() {
 		$transport = new Simples_Transport_Http() ;
 		$status = $transport->status() ;

--- a/tests/lib/Simples/Transport/HttpTest.php
+++ b/tests/lib/Simples/Transport/HttpTest.php
@@ -83,6 +83,16 @@ class Simples_Transport_HttpTest extends PHPUnit_Framework_TestCase {
 		$res = $transport->call('/test', 'HEAD');
 	}
 
+	/**
+	 * @expectedException Exception
+	 * @expectedExceptionMessage Error during the request (HTTP CODE: 400)
+	 */
+	public function testCallCurlHttpCode() {
+		$transport = new Simples_Transport_Http();
+		$transport->call('/test', 'PUT');
+		$res = $transport->call('/test', 'PATCH');
+	}
+
 	public function testMagicCall() {
 		$transport = new Simples_Transport_Http() ;
 		$status = $transport->status() ;

--- a/tests/lib/Simples/Transport/HttpTest.php
+++ b/tests/lib/Simples/Transport/HttpTest.php
@@ -62,7 +62,7 @@ class Simples_Transport_HttpTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testCallCannotJsonDecodeException() {
 		$transport = new Simples_Transport_Http();
-		$res = $transport->call('/test');
+		$transport->call('/test');
 	}
 
 	/**
@@ -71,7 +71,7 @@ class Simples_Transport_HttpTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testCallCurlReturnFalse() {
 		$transport = new Simples_Transport_Http(array( 'host' => 'nowhere' ));
-		$res = $transport->call('/test');
+		$transport->call('/test');
 	}
 
 	/**
@@ -80,7 +80,7 @@ class Simples_Transport_HttpTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testCallEmptyResponse() {
 		$transport = new Simples_Transport_Http();
-		$res = $transport->call('/test', 'HEAD');
+		$transport->call('/test', 'HEAD');
 	}
 
 	/**

--- a/tests/lib/Simples/Transport/HttpTest.php
+++ b/tests/lib/Simples/Transport/HttpTest.php
@@ -1,5 +1,4 @@
 <?php
-require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'bootstrap.php') ;
 
 class Simples_Transport_HttpTest extends PHPUnit_Framework_TestCase {
 
@@ -15,17 +14,19 @@ class Simples_Transport_HttpTest extends PHPUnit_Framework_TestCase {
 		} catch (Exception $e) {
 			$this->markTestSkipped($e->getMessage()) ;
 		}
+	}
 		
-		try {
-			$transport = new Simples_Transport_Http(array('host' => 'www.google.com', 'port' => '80')) ;
-			$transport->connect() ;
-			$this->fail();
-		} catch (Exception $e) {
-		}
-		
-		
+	/**
+	 * @expectedException Exception
+	 */
+	public function testConnectionException() {
+		$transport = new Simples_Transport_Http(array('host' => 'www.google.com', 'port' => '80')) ;
+		$transport->connect() ;
 	}
 	
+	/**
+	 * @expectedException Exception
+	 */
 	public function testCheck() {
 		$transport = new Simples_Transport_Http() ;
 		
@@ -34,13 +35,7 @@ class Simples_Transport_HttpTest extends PHPUnit_Framework_TestCase {
 			'port' => 80
 		)) ;
 		
-		try {
-			$transport->connect() ;
-		} catch(Exception $e) {
-			return ;
-		}
-		
-		$this->fail() ;
+		$transport->connect() ;
 	}
 	
 	public function testUrl() {


### PR DESCRIPTION
Method `call` of `Transport\Http` does not throw an exception when Elasticsearch return an error encoded in Json like 

```json
{"error":"RoutingMissingException[routing is required for [reunion.gestion.valid54]/[unites_physiques]/[31069]]","status":500}
```

I propose to check HTTP code of Elasticsearch response on curl request and throw an exception if the code is in `Transport\Http::$badHttpCode` array.

I fixed few things in the branch :/ The main commit is  b6dff1c.