### PR TITLE
fix: Escape pattern before use it in preg_replace

### DIFF
--- a/lib/Simples/Document.php
+++ b/lib/Simples/Document.php
@@ -144,7 +144,8 @@ class Simples_Document extends Simples_Base {
 	 */
 	protected function _options($key, array & $options) {
 		foreach($options['cast'] as $path => $_value) {
-			$_path = preg_replace('/^' . $key . '\./', '', $path) ;
+			$pattern = '/^' . preg_quote($key) . '\./';
+			$_path = preg_replace($pattern, '', $path) ;
 			if ($_path !== $path) {
 				$options['cast'][$_path] = $_value ;
 				unset($options['cast'][$path]) ;


### PR DESCRIPTION
If pattern contain special char (see PRCE), this can throw warning on
preg_replace.